### PR TITLE
Refactor Spanish game into modular components

### DIFF
--- a/components/answer-options.tsx
+++ b/components/answer-options.tsx
@@ -1,0 +1,123 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { GameWord } from "@/lib/types"
+
+interface AnswerOptionsProps {
+  word: GameWord
+  showResult: boolean
+  selectedAnswer: string | null
+  onSelect: (answer: string) => void
+}
+
+const getImageForDutchWord = (dutchWord: string): string => {
+  const imageMap: { [key: string]: string } = {
+    kat: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/kat.jpg-gCpdMb06azQX3hnxvCOEPRZY7LTfnB.jpeg",
+    hond: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/hond.jpg-0CTvgmmsdFayq4q7uMcA1h0GmKfTXu.jpeg",
+    huis: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/huis.jpg-WQws7c12ckFmSTuuQRAGpQgh8UkRoX.jpeg",
+    water: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/water.jpg-L84cvJh03PpHWGMG5mmxnLHZhEpBQ1.jpeg",
+    eten: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/eten.jpg-STC9PCSZIWvizAcvKzwDok5WQX2Ubq.jpeg",
+    boek: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/boek.jpg-sncjlhUO3jc5gYU77fdWC3lS8pEh48.jpeg",
+    auto: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/auto.jpg-nYlvQV3ctJZVTbm2WO7Fw6Kcv7zrXy.jpeg",
+    zon: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/zon.jpg-SwmR93eJZNwlb1eAsX9YkyXPDyTVzs.jpeg",
+    maan: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/maan.jpg-IwMkgZkSutUQRUhxYyQe1ZWkJ50Poi.jpeg",
+    boom: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/boom.jpg-9YMPFjdNGFMXZQUbqQmOL8waYk8QJN.jpeg",
+    tafel: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/tafel.jpg-IPLLjEloi3Uz88WkBH1mtVJfbhwgEC.jpeg",
+    bloem: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/bloem.jpg-yj0UHAmqPT7iDo9JWl9uKQXn3gVqH2.jpeg",
+    stoel: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/stoel.jpg-cFPZxum67QgQC0oaxyeCT2rGW5lWS3.jpeg",
+    raam: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/raam.jpg-lcJhqtSCsfjhKWQVNjleV7a1Kw2ee2.jpeg",
+    deur: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/deur.jpg-S6Yns5KTaXTurMeAveGIaZyd9HJrvV.jpeg",
+    spel: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/spel.jpg-KJxOXzZpG9SukvaugpMfMsN3pNAZYj.jpeg",
+    telefoon: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/telefoon.jpg-FUNKh11n8L17uOIqwkMbEDasExThX8.jpeg",
+    internet: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/internet.jpg-quE7UWjtR2LaMcg8GJnaIZaDpX1nMM.jpeg",
+    meme: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/meme.jpg-CIuKSpGUf8qTUS5Jf2AJflzxXUNpNZ.jpeg",
+    video: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/video.jpg-diAuAWPhXICHTF4Mcz4QUguuUij4du.jpeg",
+    muziek: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/muziek.jpg-a3HLyXxG8X523ZBDTYYempjBN2IpnZ.jpeg",
+    foto: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/foto.jpg-BQDfnNcyHDkmQvVqPIwFLR3MWwEGIl.jpeg",
+    chat: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/chat.jpg-cFiAeZgDB8uqR5axQPYOM9HKROUU08.jpeg",
+    school: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/school.jpg-VJ2ZG34OQx0K2ZIw19l4wRAjxngy3C.jpeg",
+    werk: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/werk.jpg-EAocMZiJLpCOQkvxQPBgxvFjcB4nnk.jpeg",
+    familie: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/familie.jpg-btRBfWNA04UICIhWcmBn1fIrvkRuBd.jpeg",
+    vriend: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/vriend.jpg-DQo2g3QWURUGplsJNvCKAisdPyPzf9.jpeg",
+    vrienden: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/vrienden-QRPHbuD1RaWP8HO8gdMBHeTh8ihl1Q.png",
+    tijd: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/tijd.jpg-njmPlPOVl9QDiOEr7i5VHwweVpeO7j.jpeg",
+    volger: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/volger.jpg-BexUJ5vcbfccBPLq8zY7VlIakGTVuy.jpeg",
+    viraal: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/viraal.jpg-GxcHXBsuuoXfQnOz16ktPD9Y9WHqNe.jpeg",
+    influencer: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/influencer.jpg-yDcbujdUBcuKxEV5j5HyNxsgWAKCoA.jpeg",
+    streaming: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/streaming.jpg-lGF8a6kw73pQlTReaDvlCrkC12OSnd.jpeg",
+    content: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/content.jpg-m9izRhbB3vZSL2edULxxVJvxalie66.jpeg",
+    algoritme: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/algoritme.jpg-jAwSG69mj44vTyRfpgEyfLB4kLE4Py.jpeg",
+    notificatie: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/notificatie.jpg-dXh96RwS0FGdWDu04jvlG9MMbCqURE.jpeg",
+    hashtag: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/hashtag.jpg-qrXdpkyX5BdXKuEVZR4HSX0Bdh1p0V.jpeg",
+    omgaan: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/omgaan.jpg-oRwwbEutb1qSse0US0MQxdPJWrGyK3.jpeg",
+    snelloop: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/snelloop.jpg-eQfdr0nUTRgojrXKYE0Gxq8D9t9tzP.jpeg",
+    gebaseerd: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/gebaseerd.jpg-P028JANRqItqFoWpEidGVUmlQLahs0.jpeg",
+    verdacht: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/verdacht.jpg-lzBwwij9eGjKXLoYrx5JJSZ81IZR0B.jpeg",
+    vertraging: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/vertraging.jpg-VLY9a6btJivBo7r5VlEs0B0OOIqoYn.jpeg",
+    pronken: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/pronken.jpg-tcth8bnvAts0hWmPHB9cSo1uA4lUBz.jpeg",
+    modificatie: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/modificatie.jpg-9VcKktaTsJ2l1vmDQzn1krYAtWDHJh.jpeg",
+    fout: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fout.jpg-cImvenhmHjVNs7XwRwvhNFRqWhX3S3.jpeg",
+    paasei: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/paasei.jpg-4AegtUBvTnfsbrBReHfxwdCcOz46Hz.jpeg",
+    cringe: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/cringe.jpg-9M5fUqib3G2T7NC6alpoFDTqA7oWBl.jpeg",
+    beginner: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/beginner.jpg-wvSZ3ojHyDIpMA5rAXw0fDcU4MMwIr.jpeg",
+    deepfake: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/deepfake.jpg-phiUtPrwJcsCY4epUK3gtImzxmH7bV.jpeg",
+    gigachad: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/gigachad.jpg-q8b7li0YZJdNQWA5ubOqYqloTv6UQ7.jpeg",
+    doge: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/doge.jpg-71ts0UsagO20DgJqRvmB9Ty7ULAFRb.jpeg",
+    karen: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/karen.jpg-8I0epF7BXDb9HdB0RzoTPneVEv6pmI.jpeg",
+    blockchain: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/blockchain.jpg-e6nBSsVTIlCvKSyp9qNVz90PazwkWc.jpeg",
+    rickroll: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/rickroll.jpg-9Xg1lwwyysz32BG9r4UKxSQc00uTc2.jpeg",
+    pepe: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/pepe.jpg-56C8fHHU0onFsz0OUf0fbH6mdD2P30.jpeg",
+    podcast: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/podcast.jpg-vXJgosQpT94ib3yw8SXeKKGagaqh4f.jpeg",
+    NFT: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/NFT.jpg-peMBpbhuUj18Q4VaFGPErOKERwfjgU.jpeg",
+    metaverse: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/metaverse.jpg-XMTqRaVptw7jRyUIemnEZTKAYZejx0.jpeg",
+    simp: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/simp.jpg-vxhMuABeQ8SMCppsyLUpmSNghNpCPT.jpeg",
+    wojak: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/wojak.jpg-jFlU2OgzUuPa2EVABpgrW8JXlKohEq.jpeg",
+  }
+
+  return (
+    imageMap[dutchWord.toLowerCase()] ||
+    `/placeholder.svg?height=48&width=48&text=${encodeURIComponent(dutchWord)}`
+  )
+}
+
+export function AnswerOptions({ word, showResult, selectedAnswer, onSelect }: AnswerOptionsProps) {
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      {word.options.map((option, index) => {
+        let buttonVariant: "default" | "secondary" | "destructive" = "secondary"
+
+        if (showResult && selectedAnswer === option.text) {
+          buttonVariant = "default"
+        } else if (showResult && option.text === word.dutch) {
+          buttonVariant = "default"
+        }
+
+        const imageUrl = getImageForDutchWord(option.text)
+
+        return (
+          <Button
+            key={index}
+            variant={buttonVariant}
+            size="lg"
+            onClick={() => onSelect(option.text)}
+            disabled={showResult}
+            className="h-20 text-lg font-semibold transition-all duration-200 hover:scale-105 font-body relative flex items-center gap-3 justify-start px-4"
+          >
+            <span className="absolute top-1 left-2 text-xs opacity-70">{index + 1}</span>
+            <img
+              src={imageUrl || "/placeholder.svg"}
+              alt={`Image for ${option.text}`}
+              className="w-12 h-12 object-cover rounded border-2 border-border/50 flex-shrink-0"
+              onError={(e) => {
+                const target = e.target as HTMLImageElement
+                target.src = `/placeholder.svg?height=48&width=48&text=${encodeURIComponent(option.text)}`
+              }}
+            />
+            <span className="flex-1 text-center">{option.text}</span>
+          </Button>
+        )
+      })}
+    </div>
+  )
+}
+

--- a/components/character-unlock-modal.tsx
+++ b/components/character-unlock-modal.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { BRAINROT_CHARACTERS } from "./italian-brainrot-characters"
+
+interface CharacterUnlockModalProps {
+  characterId: string
+  onClose: () => void
+}
+
+export function CharacterUnlockModal({ characterId, onClose }: CharacterUnlockModalProps) {
+  const character = BRAINROT_CHARACTERS.find((c) => c.id === characterId)
+  if (!character) return null
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <Card className="w-full max-w-sm mx-4 bounce-in">
+        <CardContent className="p-6 text-center">
+          <div className="text-4xl mb-4">🎉✨</div>
+          <h2 className="text-2xl font-heading font-bold mb-4">NEW CHARACTER!</h2>
+          <img
+            src={character.image || "/placeholder.svg"}
+            alt={character.name}
+            className="w-20 h-20 mx-auto rounded-full border-4 border-yellow-500 mb-4"
+          />
+          <h3 className="text-xl font-heading font-bold mb-2">{character.name}</h3>
+          <p className="text-sm text-muted-foreground mb-4">{character.description}</p>
+          <Button
+            onClick={onClose}
+            className="bg-primary hover:bg-primary/90 text-primary-foreground font-heading"
+          >
+            Awesome!
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+

--- a/components/question-display.tsx
+++ b/components/question-display.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { Loader2, Volume2 } from "lucide-react"
+import { GameWord } from "@/lib/types"
+
+interface QuestionDisplayProps {
+  word: GameWord
+  speechSupported: boolean
+  soundEnabled: boolean
+  isSpeaking: boolean
+  onSpeak: (word: string) => void
+}
+
+export function QuestionDisplay({
+  word,
+  speechSupported,
+  soundEnabled,
+  isSpeaking,
+  onSpeak,
+}: QuestionDisplayProps) {
+  return (
+    <div className="text-center mb-8">
+      <div className="flex items-center justify-center gap-4 mb-4">
+        <h2 className="text-5xl font-heading font-bold text-primary">{word.spanish}</h2>
+        {speechSupported && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onSpeak(word.spanish)}
+            disabled={isSpeaking || !soundEnabled}
+            className="h-12 w-12 rounded-full bg-transparent hover:bg-primary/10"
+            title="Speak Spanish word"
+          >
+            {isSpeaking ? <Loader2 className="w-5 h-5 animate-spin" /> : <Volume2 className="w-5 h-5" />}
+          </Button>
+        )}
+      </div>
+      <p className="text-lg text-muted-foreground font-body">What does this mean in Dutch?</p>
+      <p className="text-sm text-muted-foreground font-body mt-1">Use keys 1-4 to select answers</p>
+      <p className="text-xs text-primary font-body mt-2">✨ Collect Italian brainrot characters! ✨</p>
+    </div>
+  )
+}
+

--- a/components/spanish-learning-game.tsx
+++ b/components/spanish-learning-game.tsx
@@ -10,23 +10,11 @@ import { AchievementSystem } from "./achievement-system"
 import { SoundManager } from "./sound-manager"
 import { BrainrotCollection, getRandomCharacterToUnlock, BRAINROT_CHARACTERS } from "./italian-brainrot-characters"
 import { getWordsByDifficulty } from "@/lib/words-data"
-
-interface GameWord {
-  id: number
-  spanish: string
-  dutch: string
-  image: string
-  options: Array<{
-    text: string
-    image: string
-  }> // Updated to include image data for each option
-  difficulty: number
-  progress?: {
-    correct: number
-    incorrect: number
-    mastery: number
-  } | null
-}
+import { QuestionDisplay } from "./question-display"
+import { AnswerOptions } from "./answer-options"
+import { CharacterUnlockModal } from "./character-unlock-modal"
+import { useSpeech } from "@/hooks/use-speech"
+import { GameWord } from "@/lib/types"
 
 export function SpanishLearningGame() {
   const [gameMode, setGameMode] = useState<"welcome" | "select" | "playing" | "collection">("welcome") // Added welcome mode as initial state
@@ -52,8 +40,7 @@ export function SpanishLearningGame() {
   const [newlyUnlockedCharacter, setNewlyUnlockedCharacter] = useState<string | null>(null)
   const [showCharacterUnlock, setShowCharacterUnlock] = useState(false)
 
-  const [isSpeaking, setIsSpeaking] = useState(false)
-  const [speechSupported, setSpeechSupported] = useState(false)
+  const { speechSupported, isSpeaking, speakWord, speakWelcomeMessage } = useSpeech(soundEnabled)
 
   const [gameAnswers, setGameAnswers] = useState<
     Array<{
@@ -80,25 +67,6 @@ export function SpanishLearningGame() {
   }, [unlockedCharacters])
 
   useEffect(() => {
-    setSpeechSupported("speechSynthesis" in window)
-  }, [])
-
-  useEffect(() => {
-    if (speechSupported) {
-      speakWelcomeMessage()
-
-      // Multiple retry attempts to ensure audio plays
-      const retryTimers = [
-        setTimeout(() => speakWelcomeMessage(), 100),
-        setTimeout(() => speakWelcomeMessage(), 500),
-        setTimeout(() => speakWelcomeMessage(), 1000),
-      ]
-
-      return () => retryTimers.forEach((timer) => clearTimeout(timer))
-    }
-  }, [speechSupported]) // Removed gameMode dependency to play on component mount
-
-  useEffect(() => {
     if (currentWord && speechSupported && gameMode === "playing" && !showResult) {
       // Auto-speak the word after a short delay
       const timer = setTimeout(() => {
@@ -106,98 +74,8 @@ export function SpanishLearningGame() {
       }, 500)
       return () => clearTimeout(timer)
     }
-  }, [currentWordIndex, gameMode, showResult])
+  }, [currentWordIndex, gameMode, showResult, currentWord, speechSupported, speakWord])
 
-  const getImageForDutchWord = (dutchWord: string): string => {
-    const imageMap: { [key: string]: string } = {
-      kat: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/kat.jpg-gCpdMb06azQX3hnxvCOEPRZY7LTfnB.jpeg",
-      hond: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/hond.jpg-0CTvgmmsdFayq4q7uMcA1h0GmKfTXu.jpeg",
-      huis: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/huis.jpg-WQws7c12ckFmSTuuQRAGpQgh8UkRoX.jpeg",
-      water: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/water.jpg-L84cvJh03PpHWGMG5mmxnLHZhEpBQ1.jpeg",
-      eten: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/eten.jpg-STC9PCSZIWvizAcvKzwDok5WQX2Ubq.jpeg",
-      boek: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/boek.jpg-sncjlhUO3jc5gYU77fdWC3lS8pEh48.jpeg",
-      auto: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/auto.jpg-nYlvQV3ctJZVTbm2WO7Fw6Kcv7zrXy.jpeg",
-      zon: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/zon.jpg-SwmR93eJZNwlb1eAsX9YkyXPDyTVzs.jpeg",
-      maan: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/maan.jpg-IwMkgZkSutUQRUhxYyQe1ZWkJ50Poi.jpeg",
-      boom: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/boom.jpg-9YMPFjdNGFMXZQUbqQmOL8waYk8QJN.jpeg",
-      tafel: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/tafel.jpg-IPLLjEloi3Uz88WkBH1mtVJfbhwgEC.jpeg",
-      bloem: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/bloem.jpg-yj0UHAmqPT7iDo9JWl9uKQXn3gVqH2.jpeg",
-      stoel: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/stoel.jpg-cFPZxum67QgQC0oaxyeCT2rGW5lWS3.jpeg",
-      raam: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/raam.jpg-lcJhqtSCsfjhKWQVNjleV7a1Kw2ee2.jpeg",
-      deur: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/deur.jpg-S6Yns5KTaXTurMeAveGIaZyd9HJrvV.jpeg",
-      spel: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/spel.jpg-KJxOXzZpG9SukvaugpMfMsN3pNAZYj.jpeg",
-      telefoon:
-        "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/telefoon.jpg-FUNKh11n8L17uOIqwkMbEDasExThX8.jpeg",
-      internet:
-        "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/internet.jpg-quE7UWjtR2LaMcg8GJnaIZaDpX1nMM.jpeg",
-      meme: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/meme.jpg-CIuKSpGUf8qTUS5Jf2AJflzxXUNpNZ.jpeg",
-      video: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/video.jpg-diAuAWPhXICHTF4Mcz4QUguuUij4du.jpeg",
-      muziek: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/muziek.jpg-a3HLyXxG8X523ZBDTYYempjBN2IpnZ.jpeg",
-      foto: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/foto.jpg-BQDfnNcyHDkmQvVqPIwFLR3MWwEGIl.jpeg",
-      chat: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/chat.jpg-cFiAeZgDB8uqR5axQPYOM9HKROUU08.jpeg",
-      school: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/school.jpg-VJ2ZG34OQx0K2ZIw19l4wRAjxngy3C.jpeg",
-      werk: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/werk.jpg-EAocMZiJLpCOQkvxQPBgxvFjcB4nnk.jpeg",
-      familie:
-        "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/familie.jpg-btRBfWNA04UICIhWcmBn1fIrvkRuBd.jpeg",
-      vriend: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/vriend.jpg-DQo2g3QWURUGplsJNvCKAisdPyPzf9.jpeg",
-      vrienden: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/vrienden-QRPHbuD1RaWP8HO8gdMBHeTh8ihl1Q.png",
-      tijd: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/tijd.jpg-njmPlPOVl9QDiOEr7i5VHwweVpeO7j.jpeg",
-      volger: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/volger.jpg-BexUJ5vcbfccBPLq8zY7VlIakGTVuy.jpeg",
-      viraal: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/viraal.jpg-GxcHXBsuuoXfQnOz16ktPD9Y9WHqNe.jpeg",
-      influencer:
-        "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/influencer.jpg-yDcbujdUBcuKxEV5j5HyNxsgWAKCoA.jpeg",
-      streaming:
-        "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/streaming.jpg-lGF8a6kw73pQlTReaDvlCrkC12OSnd.jpeg",
-      content:
-        "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/content.jpg-m9izRhbB3vZSL2edULxxVJvxalie66.jpeg",
-      algoritme:
-        "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/algoritme.jpg-jAwSG69mj44vTyRfpgEyfLB4kLE4Py.jpeg",
-      notificatie:
-        "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/notificatie.jpg-dXh96RwS0FGdWDu04jvlG9MMbCqURE.jpeg",
-      hashtag:
-        "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/hashtag.jpg-qrXdpkyX5BdXKuEVZR4HSX0Bdh1p0V.jpeg",
-      omgaan: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/omgaan.jpg-oRwwbEutb1qSse0US0MQxdPJWrGyK3.jpeg",
-      snelloop:
-        "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/snelloop.jpg-eQfdr0nUTRgojrXKYE0Gxq8D9t9tzP.jpeg",
-      gebaseerd:
-        "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/gebaseerd.jpg-P028JANRqItqFoWpEidGVUmlQLahs0.jpeg",
-      verdacht:
-        "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/verdacht.jpg-lzBwwij9eGjKXLoYrx5JJSZ81IZR0B.jpeg",
-      vertraging:
-        "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/vertraging.jpg-VLY9a6btJivBo7r5VlEs0B0OOIqoYn.jpeg",
-      pronken:
-        "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/pronken.jpg-tcth8bnvAts0hWmPHB9cSo1uA4lUBz.jpeg",
-      modificatie:
-        "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/modificatie.jpg-9VcKktaTsJ2l1vmDQzn1krYAtWDHJh.jpeg",
-      fout: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fout.jpg-cImvenhmHjVNs7XwRwvhNFRqWhX3S3.jpeg",
-      paasei: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/paasei.jpg-4AegtUBvTnfsbrBReHfxwdCcOz46Hz.jpeg",
-      cringe: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/cringe.jpg-9M5fUqib3G2T7NC6alpoFDTqA7oWBl.jpeg",
-      beginner:
-        "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/beginner.jpg-wvSZ3ojHyDIpMA5rAXw0fDcU4MMwIr.jpeg",
-      deepfake:
-        "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/deepfake.jpg-phiUtPrwJcsCY4epUK3gtImzxmH7bV.jpeg",
-      gigachad:
-        "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/gigachad.jpg-q8b7li0YZJdNQWA5ubOqYqloTv6UQ7.jpeg",
-      doge: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/doge.jpg-71ts0UsagO20DgJqRvmB9Ty7ULAFRb.jpeg",
-      karen: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/karen.jpg-8I0epF7BXDb9HdB0RzoTPneVEv6pmI.jpeg",
-      blockchain:
-        "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/blockchain.jpg-e6nBSsVTIlCvKSyp9qNVz90PazwkWc.jpeg",
-      rickroll:
-        "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/rickroll.jpg-9Xg1lwwyysz32BG9r4UKxSQc00uTc2.jpeg",
-      pepe: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/pepe.jpg-56C8fHHU0onFsz0OUf0fbH6mdD2P30.jpeg",
-      podcast:
-        "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/podcast.jpg-vXJgosQpT94ib3yw8SXeKKGagaqh4f.jpeg",
-      NFT: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/NFT.jpg-peMBpbhuUj18Q4VaFGPErOKERwfjgU.jpeg",
-      metaverse:
-        "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/metaverse.jpg-XMTqRaVptw7jRyUIemnEZTKAYZejx0.jpeg",
-      simp: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/simp.jpg-vxhMuABeQ8SMCppsyLUpmSNghNpCPT.jpeg",
-      wojak: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/wojak.jpg-jFlU2OgzUuPa2EVABpgrW8JXlKohEq.jpeg",
-    }
-
-    return (
-      imageMap[dutchWord.toLowerCase()] || `/placeholder.svg?height=48&width=48&text=${encodeURIComponent(dutchWord)}`
-    )
-  }
 
   const loadWords = async (difficulty?: number) => {
     setLoading(true)
@@ -206,36 +84,19 @@ export function SpanishLearningGame() {
       const response = await fetch(url)
       if (response.ok) {
         const data = await response.json()
-        const wordsWithImages = data.words.map((word: GameWord) => ({
-          ...word,
-          options: word.options.map((option: any) => ({
-            ...option,
-            image: getImageForDutchWord(option.text),
-          })),
-        }))
-        setWords(wordsWithImages)
+        setWords(data.words)
         setGameStartTime(Date.now())
       } else {
         console.error("Failed to load words")
         const fallbackWords = getWordsByDifficulty(difficulty)
         const gameWords = fallbackWords.map((word) => {
-          // Get 3 random incorrect options from other words
           const otherWords = fallbackWords.filter((w) => w.id !== word.id)
           const incorrectOptions = otherWords
             .sort(() => Math.random() - 0.5)
             .slice(0, 3)
-            .map((w) => ({
-              text: w.dutch_translation,
-              image: getImageForDutchWord(w.dutch_translation),
-            }))
+            .map((w) => ({ text: w.dutch_translation }))
 
-          // Add the correct option
-          const correctOption = {
-            text: word.dutch_translation,
-            image: getImageForDutchWord(word.dutch_translation),
-          }
-
-          // Combine and shuffle all options
+          const correctOption = { text: word.dutch_translation }
           const allOptions = [correctOption, ...incorrectOptions].sort(() => Math.random() - 0.5)
 
           return {
@@ -253,23 +114,13 @@ export function SpanishLearningGame() {
       console.error("Error loading words:", error)
       const fallbackWords = getWordsByDifficulty(difficulty)
       const gameWords = fallbackWords.map((word) => {
-        // Get 3 random incorrect options from other words
         const otherWords = fallbackWords.filter((w) => w.id !== word.id)
         const incorrectOptions = otherWords
           .sort(() => Math.random() - 0.5)
           .slice(0, 3)
-          .map((w) => ({
-            text: w.dutch_translation,
-            image: getImageForDutchWord(w.dutch_translation),
-          }))
+          .map((w) => ({ text: w.dutch_translation }))
 
-        // Add the correct option
-        const correctOption = {
-          text: word.dutch_translation,
-          image: getImageForDutchWord(word.dutch_translation),
-        }
-
-        // Combine and shuffle all options
+        const correctOption = { text: word.dutch_translation }
         const allOptions = [correctOption, ...incorrectOptions].sort(() => Math.random() - 0.5)
 
         return {
@@ -790,34 +641,10 @@ export function SpanishLearningGame() {
       />
 
       {showCharacterUnlock && newlyUnlockedCharacter && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <Card className="w-full max-w-sm mx-4 bounce-in">
-            <CardContent className="p-6 text-center">
-              <div className="text-4xl mb-4">🎉✨</div>
-              <h2 className="text-2xl font-heading font-bold mb-4">NEW CHARACTER!</h2>
-              {(() => {
-                const character = BRAINROT_CHARACTERS.find((c) => c.id === newlyUnlockedCharacter)
-                return character ? (
-                  <>
-                    <img
-                      src={character.image || "/placeholder.svg"}
-                      alt={character.name}
-                      className="w-20 h-20 mx-auto rounded-full border-4 border-yellow-500 mb-4"
-                    />
-                    <h3 className="text-xl font-heading font-bold mb-2">{character.name}</h3>
-                    <p className="text-sm text-muted-foreground mb-4">{character.description}</p>
-                  </>
-                ) : null
-              })()}
-              <Button
-                onClick={() => setShowCharacterUnlock(false)}
-                className="bg-primary hover:bg-primary/90 text-primary-foreground font-heading"
-              >
-                Awesome!
-              </Button>
-            </CardContent>
-          </Card>
-        </div>
+        <CharacterUnlockModal
+          characterId={newlyUnlockedCharacter}
+          onClose={() => setShowCharacterUnlock(false)}
+        />
       )}
 
       <div className="w-full max-w-2xl">
@@ -850,71 +677,19 @@ export function SpanishLearningGame() {
         {/* Game Card */}
         <Card className={`w-full ${animationClass}`}>
           <CardContent className="p-8">
-            {/* Spanish Word */}
-            <div className="text-center mb-8">
-              <div className="flex items-center justify-center gap-4 mb-4">
-                <h2 className="text-5xl font-heading font-bold text-primary">{currentWord.spanish}</h2>
-                {speechSupported && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => speakWord(currentWord.spanish)}
-                    disabled={isSpeaking || !soundEnabled}
-                    className="h-12 w-12 rounded-full bg-transparent hover:bg-primary/10"
-                    title="Speak Spanish word"
-                  >
-                    {isSpeaking ? <Loader2 className="w-5 h-5 animate-spin" /> : <Volume2 className="w-5 h-5" />}
-                  </Button>
-                )}
-              </div>
-              <p className="text-lg text-muted-foreground font-body">What does this mean in Dutch?</p>
-              <p className="text-sm text-muted-foreground font-body mt-1">Use keys 1-4 to select answers</p>
-              <p className="text-xs text-primary font-body mt-2">✨ Collect Italian brainrot characters! ✨</p>
-            </div>
-
-            {/* Answer Options */}
-            <div className="grid grid-cols-2 gap-4">
-              {currentWord.options.map((option, index) => {
-                let buttonVariant: "default" | "secondary" | "destructive" = "secondary"
-
-                if (showResult && selectedAnswer === option.text) {
-                  buttonVariant = "default"
-                } else if (showResult && option.text === currentWord.dutch) {
-                  buttonVariant = "default"
-                }
-
-                const imageUrl = getImageForDutchWord(option.text)
-
-                console.log(`[v0] Button ${index + 1} - Text: ${option.text}, Image URL: ${imageUrl}`)
-
-                return (
-                  <Button
-                    key={index}
-                    variant={buttonVariant}
-                    size="lg"
-                    onClick={() => handleAnswerSelect(option.text)} // Use option.text for selection
-                    disabled={showResult}
-                    className="h-20 text-lg font-semibold transition-all duration-200 hover:scale-105 font-body relative flex items-center gap-3 justify-start px-4"
-                  >
-                    <span className="absolute top-1 left-2 text-xs opacity-70">{index + 1}</span>
-                    <img
-                      src={imageUrl || "/placeholder.svg"}
-                      alt={`Image for ${option.text}`}
-                      className="w-12 h-12 object-cover rounded border-2 border-border/50 flex-shrink-0"
-                      onLoad={() => {
-                        console.log(`[v0] Image loaded successfully for: ${option.text}`)
-                      }}
-                      onError={(e) => {
-                        const target = e.target as HTMLImageElement
-                        console.log(`[v0] Image failed to load for: ${option.text}, trying fallback`)
-                        target.src = `/placeholder.svg?height=48&width=48&text=${encodeURIComponent(option.text)}`
-                      }}
-                    />
-                    <span className="flex-1 text-center">{option.text}</span> {/* Use option.text for display */}
-                  </Button>
-                )
-              })}
-            </div>
+            <QuestionDisplay
+              word={currentWord}
+              speechSupported={speechSupported}
+              soundEnabled={soundEnabled}
+              isSpeaking={isSpeaking}
+              onSpeak={speakWord}
+            />
+            <AnswerOptions
+              word={currentWord}
+              showResult={showResult}
+              selectedAnswer={selectedAnswer}
+              onSelect={handleAnswerSelect}
+            />
 
             {/* Result Message */}
             {showResult && (

--- a/hooks/use-speech.ts
+++ b/hooks/use-speech.ts
@@ -1,0 +1,100 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+export function useSpeech(soundEnabled: boolean) {
+  const [isSpeaking, setIsSpeaking] = useState(false)
+  const [speechSupported, setSpeechSupported] = useState(false)
+
+  const speakWord = (word: string) => {
+    if (!speechSupported || isSpeaking) return
+
+    window.speechSynthesis.cancel()
+
+    const utterance = new SpeechSynthesisUtterance(word)
+    utterance.lang = "es-ES"
+    utterance.rate = 0.7
+    utterance.pitch = 2.2
+    utterance.volume = soundEnabled ? 1 : 0
+
+    utterance.onstart = () => setIsSpeaking(true)
+    utterance.onend = () => setIsSpeaking(false)
+    utterance.onerror = () => setIsSpeaking(false)
+
+    window.speechSynthesis.speak(utterance)
+  }
+
+  const speakWelcomeMessage = () => {
+    if (!speechSupported) return
+
+    window.speechSynthesis.cancel()
+
+    const message = "Hello Papacito Max, are you ready to collect Italian Brainrot Figures?"
+    const utterance = new SpeechSynthesisUtterance(message)
+
+    utterance.lang = "es-US"
+    utterance.rate = 0.7
+    utterance.pitch = 2.5
+    utterance.volume = 1
+
+    const voices = window.speechSynthesis.getVoices()
+    const funnyVoice =
+      voices.find(
+        (voice) =>
+          (voice.lang.startsWith("es") || voice.name.toLowerCase().includes("spanish")) &&
+          (voice.name.toLowerCase().includes("female") ||
+            voice.name.toLowerCase().includes("woman") ||
+            voice.name.toLowerCase().includes("maria") ||
+            voice.name.toLowerCase().includes("carmen") ||
+            voice.name.toLowerCase().includes("sofia") ||
+            voice.name.toLowerCase().includes("isabella")),
+      ) ||
+      voices.find(
+        (voice) =>
+          voice.name.toLowerCase().includes("child") ||
+          voice.name.toLowerCase().includes("young") ||
+          voice.name.toLowerCase().includes("high"),
+      ) ||
+      voices.find((voice) => voice.lang.startsWith("es"))
+
+    if (funnyVoice) {
+      utterance.voice = funnyVoice
+    }
+
+    utterance.onstart = () => {
+      setIsSpeaking(true)
+    }
+    utterance.onend = () => {
+      setIsSpeaking(false)
+    }
+    utterance.onerror = () => {
+      setIsSpeaking(false)
+      setTimeout(() => {
+        if (!isSpeaking) {
+          window.speechSynthesis.speak(utterance)
+        }
+      }, 200)
+    }
+
+    window.speechSynthesis.speak(utterance)
+  }
+
+  useEffect(() => {
+    setSpeechSupported("speechSynthesis" in window)
+  }, [])
+
+  useEffect(() => {
+    if (speechSupported) {
+      speakWelcomeMessage()
+      const retryTimers = [
+        setTimeout(() => speakWelcomeMessage(), 100),
+        setTimeout(() => speakWelcomeMessage(), 500),
+        setTimeout(() => speakWelcomeMessage(), 1000),
+      ]
+      return () => retryTimers.forEach((timer) => clearTimeout(timer))
+    }
+  }, [speechSupported])
+
+  return { isSpeaking, speechSupported, speakWord, speakWelcomeMessage }
+}
+

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -33,3 +33,17 @@ export interface GameQuestion {
   options: string[]
   correctAnswer: string
 }
+
+export interface GameWord {
+  id: number
+  spanish: string
+  dutch: string
+  image: string | null
+  options: Array<{ text: string }>
+  difficulty: number
+  progress?: {
+    correct: number
+    incorrect: number
+    mastery: number
+  } | null
+}


### PR DESCRIPTION
## Summary
- split question display, answer options, character unlock modal, and speech logic into dedicated components and hooks
- simplify `SpanishLearningGame` to orchestrate game state and render new modules

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b746ec4e38832eb7aac8d91eb42959